### PR TITLE
Fix shader include

### DIFF
--- a/shaders/modular/opaque_color_shader.gdshader
+++ b/shaders/modular/opaque_color_shader.gdshader
@@ -17,4 +17,4 @@ shader_type spatial;
 #define OPAQUE
 
 // Give it the color shader (affects vertex() and fragment() functions).
-#include "res://shaders/monolithic/object_shader.gdshaderinc"
+#include "res://shaders/modular/color_shader.gdshaderinc"


### PR DESCRIPTION
Hi,

currently the `shaders/modular/opaque_color_shader.gdshader`
includes `shaders/monolithic/object_shader.gdshaderinc`. This works because the `CAMERA_VISIBLE_LAYERS` are correctly set.
Yet it is probably not the intended include which should be `shaders/modular/color_shader.gdshaderinc`.

Feel free to take ownership of this commit or discard it if I got this wrong.

Thank you for this example repository!

-ClaasJG